### PR TITLE
af-magic theme: Space before branch name for hg and git

### DIFF
--- a/themes/af-magic.zsh-theme
+++ b/themes/af-magic.zsh-theme
@@ -31,13 +31,13 @@ RPS1='${return_code}'
 RPS1+=' $my_gray%n@%m%{$reset_color%}%'
 
 # git settings
-ZSH_THEME_GIT_PROMPT_PREFIX="$FG[075]($FG[078]"
+ZSH_THEME_GIT_PROMPT_PREFIX=" $FG[075]($FG[078]"
 ZSH_THEME_GIT_PROMPT_CLEAN=""
 ZSH_THEME_GIT_PROMPT_DIRTY="$my_orange*%{$reset_color%}"
 ZSH_THEME_GIT_PROMPT_SUFFIX="$FG[075])%{$reset_color%}"
 
 # hg settings
-ZSH_THEME_HG_PROMPT_PREFIX="$FG[075]($FG[078]"
+ZSH_THEME_HG_PROMPT_PREFIX=" $FG[075]($FG[078]"
 ZSH_THEME_HG_PROMPT_CLEAN=""
 ZSH_THEME_HG_PROMPT_DIRTY="$my_orange*%{$reset_color%}"
 ZSH_THEME_HG_PROMPT_SUFFIX="$FG[075])%{$reset_color%}"


### PR DESCRIPTION
af-magic theme looks better. Same style for all prefixes.

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Added space before Hg and Git branch name into prefix var.